### PR TITLE
feature: change email flow

### DIFF
--- a/src/app/(authed)/change-email/page.tsx
+++ b/src/app/(authed)/change-email/page.tsx
@@ -1,0 +1,30 @@
+import ChangeEmailForm from "@/components/ChangeEmailPage/ChangeEmailForm";
+import { Button } from "@/components/ui/button";
+import { createServerSession } from "@/lib/session/server";
+
+const ChangeEmailPage = async (): Promise<React.JSX.Element> => {
+  const session = await createServerSession();
+
+  return (
+    <div className="h-96 text-center content-center">
+      <ChangeEmailForm />
+      <h2 className="text-2xl font-bold">
+        If you do not want to change the email, please, proceed back to other
+        pages.
+      </h2>
+      <div className="flex justify-center gap-8 mt-8">
+        <Button variant="link" className="text-4xl p-0 text-purple-800">
+          <a href="/dashboard">Dashboard</a>
+        </Button>
+
+        {session.hasUserId() && (
+          <Button variant="link" className="text-4xl p-0 text-purple-800">
+            <a href={`/users/${session.getUserId()}`}>Profile</a>
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ChangeEmailPage;

--- a/src/app/(unauthed)/layout.tsx
+++ b/src/app/(unauthed)/layout.tsx
@@ -9,7 +9,7 @@ type Props = {
 };
 
 const UnauthenticatedLayout = ({ children }: Props) => {
-  const { setSession } = useContext(SessionContext);
+  const { setSession, session } = useContext(SessionContext);
 
   useEffect(() => {
     setSession(new Session());
@@ -17,7 +17,7 @@ const UnauthenticatedLayout = ({ children }: Props) => {
 
   return (
     <div className="h-full">
-      <AppHeader isAuthenticated={false} />
+      <AppHeader isAuthenticated={session.hasToken()} />
       <div className="relative flex h-full p-9 w-full">
         <div className="flex flex-grow-1 flex-wrap justify-center">
           {children}

--- a/src/components/ChangeEmailPage/ChangeEmailForm/ChangeEmailForm.tsx
+++ b/src/components/ChangeEmailPage/ChangeEmailForm/ChangeEmailForm.tsx
@@ -1,0 +1,95 @@
+"use client";
+import { Alert, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { UserContext } from "@/lib/state/UserContext/UserContext";
+import { AlertCircleIcon } from "lucide-react";
+import { useContext } from "react";
+import { useChangeUserEmail } from "./hooks";
+import { zodResolver } from "@hookform/resolvers/zod";
+import z from "zod";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { useForm } from "react-hook-form";
+
+const formSchema = z.object({
+  newEmail: z.email({
+    message: "Please, provide a valid email!",
+  }),
+});
+
+const ChangeEmailForm = (): React.JSX.Element => {
+  const { user } = useContext(UserContext);
+  const { changeEmailToken, onSubmit, isLoading, error } = useChangeUserEmail();
+
+  const form = useForm<{ newEmail: string }>({
+    disabled: isLoading,
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      newEmail: "",
+    },
+  });
+
+  return (
+    <div className="mb-4">
+      <h1 className="text-4xl font-bold text-purple-800">
+        Hi, {user?.firstName ?? "User"}!
+      </h1>
+      {user?.id && changeEmailToken ? (
+        <>
+          <h2 className="text-2xl font-bold">
+            To change the email, enter a new email and click submit button.
+            After change is applied, you will need to sign in again.
+          </h2>
+          <Form {...form}>
+            <form
+              className="w-full justify-center"
+              onSubmit={form.handleSubmit(onSubmit)}
+            >
+              <FormField
+                control={form?.control}
+                name="newEmail"
+                render={({ field }) => (
+                  <FormItem className="mb-4 w-96 mt-4 justify-self-center max-h-36">
+                    <FormLabel>New Email</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <Button
+                className="my-2 w-1/5 h-10 text-lg"
+                type="submit"
+                disabled={isLoading}
+              >
+                {isLoading && <Spinner />}
+                Submit
+              </Button>
+
+              {error && (
+                <Alert variant="destructive">
+                  <AlertCircleIcon />
+                  <AlertTitle>{error}</AlertTitle>
+                </Alert>
+              )}
+            </form>
+          </Form>
+        </>
+      ) : (
+        <h3 className="text-2xl">We cannot change your email at the moment.</h3>
+      )}
+    </div>
+  );
+};
+
+export default ChangeEmailForm;

--- a/src/components/ChangeEmailPage/ChangeEmailForm/hooks/index.ts
+++ b/src/components/ChangeEmailPage/ChangeEmailForm/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./useChangeUserEmail";

--- a/src/components/ChangeEmailPage/ChangeEmailForm/hooks/useChangeUserEmail.ts
+++ b/src/components/ChangeEmailPage/ChangeEmailForm/hooks/useChangeUserEmail.ts
@@ -1,0 +1,68 @@
+"use client";
+import { AuthService } from "@/lib/api/AuthService/AuthService";
+import { UserService } from "@/lib/api/UserService/UserService";
+import { SessionContext } from "@/lib/session/SessionContext";
+import { UserContext } from "@/lib/state/UserContext/UserContext";
+import { ROUTES, RoutesId } from "@/routes";
+import { useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { ApiError } from "next/dist/server/api-utils";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useContext } from "react";
+
+export type UseChangeUserEmail = {
+  changeEmailToken: string | null;
+  onSubmit: (values: { newEmail: string }) => void;
+  isLoading: boolean;
+  error?: string;
+};
+
+export const useChangeUserEmail = (): UseChangeUserEmail => {
+  const { session } = useContext(SessionContext);
+  const { user, setUser } = useContext(UserContext);
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const changeEmailToken: string =
+    searchParams.get("change-email-token")?.replaceAll("\\", "") ?? "";
+
+  const mutationVerifyUserEmail = useMutation<
+    void,
+    AxiosError<ApiError>,
+    string
+  >({
+    mutationFn: async (newEmail: string): Promise<void> => {
+      try {
+        const userClient = new UserService(session);
+
+        const { data } = await userClient.changeUserEmail(user?.id ?? "", {
+          changeEmailToken: changeEmailToken,
+          newEmail,
+        });
+
+        setUser(data);
+
+        const token = session.getToken();
+
+        if (token) {
+          const authClient = new AuthService();
+          await authClient.signOut(token);
+        }
+      } finally {
+        session.clear();
+        router.push(ROUTES[RoutesId.home].url);
+      }
+    },
+  });
+
+  const onSubmit = (values: { newEmail: string }) => {
+    mutationVerifyUserEmail.mutateAsync(values.newEmail);
+  };
+
+  return {
+    changeEmailToken,
+    onSubmit,
+    error: mutationVerifyUserEmail.error?.message,
+    isLoading: mutationVerifyUserEmail.isPending,
+  };
+};

--- a/src/components/ChangeEmailPage/ChangeEmailForm/index.ts
+++ b/src/components/ChangeEmailPage/ChangeEmailForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ChangeEmailForm";

--- a/src/components/ChangeEmailPage/index.ts
+++ b/src/components/ChangeEmailPage/index.ts
@@ -1,0 +1,1 @@
+export * from "./ChangeEmailForm";

--- a/src/components/UserProfilePage/UserProfileForm/UserProfileForm.tsx
+++ b/src/components/UserProfilePage/UserProfileForm/UserProfileForm.tsx
@@ -10,7 +10,11 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { UserProfileFormType, useUserProfileForm } from "./hooks";
+import {
+  useRequestChanges,
+  UserProfileFormType,
+  useUserProfileForm,
+} from "./hooks";
 import z from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -57,16 +61,18 @@ const formSchema = z.object({
 });
 
 const UserProfileFrom = ({ user }: Props): React.JSX.Element => {
+  const { isEditingCurrentUser, editedUser, handleSave, isLoading } =
+    useUserProfileForm({
+      user,
+    });
+
   const {
-    isEditingCurrentUser,
-    editedUser,
-    handleSave,
-    isLoading,
     isRequestVerificationLoading,
     requestEmailVerification,
-  } = useUserProfileForm({
-    user,
-  });
+    isRequestChangeUserEmailLoading,
+    requestChangeUserEmail,
+  } = useRequestChanges({ user });
+
   const { countryOptions, isLoading: isCountryOptionsLoading } = useCountries();
 
   const form = useForm<UserProfileFormType>({
@@ -127,6 +133,17 @@ const UserProfileFrom = ({ user }: Props): React.JSX.Element => {
           </div>
           <div>
             Your email is <span className="font-bold italic">{user.email}</span>
+          </div>
+          <div>
+            <Button
+              className="p-0"
+              variant={"link"}
+              onClick={requestChangeUserEmail}
+              type="button"
+            >
+              Request Change User Email
+              {isRequestChangeUserEmailLoading && <Spinner />}
+            </Button>
           </div>
           <FormField
             control={form?.control}

--- a/src/components/UserProfilePage/UserProfileForm/hooks/index.ts
+++ b/src/components/UserProfilePage/UserProfileForm/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from "./useUserProfileForm";
+export * from "./useRequestChanges";

--- a/src/components/UserProfilePage/UserProfileForm/hooks/useRequestChanges.ts
+++ b/src/components/UserProfilePage/UserProfileForm/hooks/useRequestChanges.ts
@@ -1,0 +1,67 @@
+import { UserService } from "@/lib/api/UserService/UserService";
+import { User } from "@/lib/models/user";
+import { SessionContext } from "@/lib/session/SessionContext";
+import { useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { ApiError } from "next/dist/server/api-utils";
+import { useContext } from "react";
+
+export type UseRequestChanges = {
+  requestEmailVerification: () => Promise<void>;
+  isRequestVerificationLoading: boolean;
+  requestChangeUserEmail: () => Promise<void>;
+  isRequestChangeUserEmailLoading: boolean;
+};
+
+type Props = {
+  user: User;
+};
+
+export const useRequestChanges = ({ user }: Props): UseRequestChanges => {
+  const { session } = useContext(SessionContext);
+
+  const mutationRequestEmailVerification = useMutation<
+    void,
+    AxiosError<ApiError>
+  >({
+    mutationFn: async (): Promise<void> => {
+      const client = new UserService(session);
+
+      return client.requestUserEmailVerification(user.id ?? "");
+    },
+  });
+
+  const requestEmailVerification = async () => {
+    try {
+      await mutationRequestEmailVerification.mutate();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const mutationRequestChangeUserEmail = useMutation<
+    void,
+    AxiosError<ApiError>
+  >({
+    mutationFn: async (): Promise<void> => {
+      const client = new UserService(session);
+
+      return client.requestChangeUserEmail(user.id ?? "");
+    },
+  });
+
+  const requestChangeUserEmail = async () => {
+    try {
+      await mutationRequestChangeUserEmail.mutate();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return {
+    isRequestVerificationLoading: mutationRequestEmailVerification.isPending,
+    requestEmailVerification,
+    isRequestChangeUserEmailLoading: mutationRequestChangeUserEmail.isPending,
+    requestChangeUserEmail,
+  };
+};

--- a/src/components/UserProfilePage/UserProfileForm/hooks/useUserProfileForm.ts
+++ b/src/components/UserProfilePage/UserProfileForm/hooks/useUserProfileForm.ts
@@ -27,8 +27,6 @@ export type UseUserProfileForm = {
   editedUser: User;
   handleSave: (payload: UserProfileFormType) => void;
   isLoading: boolean;
-  requestEmailVerification: () => Promise<void>;
-  isRequestVerificationLoading: boolean;
 };
 
 export const useUserProfileForm = ({ user }: Props): UseUserProfileForm => {
@@ -75,31 +73,10 @@ export const useUserProfileForm = ({ user }: Props): UseUserProfileForm => {
     }
   };
 
-  const mutationRequestEmailVerification = useMutation<
-    void,
-    AxiosError<ApiError>
-  >({
-    mutationFn: async (): Promise<void> => {
-      const client = new UserService(session);
-
-      return client.requestUserEmailVerification(user.id ?? "");
-    },
-  });
-
-  const requestEmailVerification = async () => {
-    try {
-      await mutationRequestEmailVerification.mutate();
-    } catch (e) {
-      console.error(e);
-    }
-  };
-
   return {
     isEditingCurrentUser,
     editedUser,
     handleSave,
     isLoading: mutationUpdateCommonFields.isPending,
-    isRequestVerificationLoading: mutationRequestEmailVerification.isPending,
-    requestEmailVerification,
   };
 };

--- a/src/lib/api/UserService/UserService.ts
+++ b/src/lib/api/UserService/UserService.ts
@@ -3,7 +3,11 @@ import { BaseService } from "../BaseService";
 import { userManagementApiClient } from "../axios";
 import { ApiResponse } from "../types";
 import { User } from "@/lib/models/user";
-import { UpdateUserCommonFields, VerifyUserEmailPayload } from "./types";
+import {
+  ChangeUserEmailPayload,
+  UpdateUserCommonFields,
+  VerifyUserEmailPayload,
+} from "./types";
 
 export class UserService extends BaseService {
   constructor(session: Session) {
@@ -40,5 +44,20 @@ export class UserService extends BaseService {
     return await this.apiClient.post(
       `/users/${id}/request-user-email-verification`
     );
+  }
+
+  async requestChangeUserEmail(id: string): Promise<void> {
+    return await this.apiClient.post(`/users/${id}/request-change-user-email`);
+  }
+
+  async changeUserEmail(
+    id: string,
+    payload: ChangeUserEmailPayload
+  ): Promise<ApiResponse<User>> {
+    return (
+      await this.apiClient.patch(`/users/${id}/change-email`, {
+        ...payload,
+      })
+    ).data;
   }
 }

--- a/src/lib/api/UserService/types.ts
+++ b/src/lib/api/UserService/types.ts
@@ -12,3 +12,8 @@ export type UpdateUserCommonFields = {
 export type VerifyUserEmailPayload = {
   verificationToken: string;
 };
+
+export type ChangeUserEmailPayload = {
+  changeEmailToken: string;
+  newEmail: string;
+};


### PR DESCRIPTION
In the scope of this PR:

1. Add change user email flow: user requests the email change on the profile page, then via email link is delivered, in the link there is a token which is used to verify that user email is changed for correct user, then after user submits new email, the session is invalidated and user redirected to sign in 